### PR TITLE
Fix Windows PCI subsystem ID string generation.

### DIFF
--- a/library/src/WmiQuery.cpp
+++ b/library/src/WmiQuery.cpp
@@ -47,7 +47,7 @@ namespace
 		// <https://docs.microsoft.com/en-us/windows-hardware/drivers/install/identifiers-for-pci-devices>
 		// and insert wildcards for the subsystem vendor ID (if absent) and the device instance
 		return fmt::format(
-			L"PCI\\\\VEN_{:0>4X}&DEV_{:0>4X}&SUBSYS_{:0>4X}{}&REV_{:0>2X}%",
+			L"PCI\\\\VEN_{:0>4X}&DEV_{:0>4X}&SUBSYS_{:0>8X}{}&REV_{:0>2X}%",
 			dxHardwareID.vendorID,
 			dxHardwareID.deviceID,
 			dxHardwareID.subSysID,


### PR DESCRIPTION
PCI device subsystem IDs are always 8 digits (4+4) on Windows.

https://learn.microsoft.com/en-us/windows-hardware/drivers/install/identifiers-for-pci-devices

Verified this empirically.  Device plugin fails with the existing code but succeeds finding the device with the new code.
